### PR TITLE
Removes left padding from pros/cons sections

### DIFF
--- a/src/css/review.css
+++ b/src/css/review.css
@@ -79,7 +79,6 @@
 }
 
 .summaryProsOrCons__rest {
-  padding-left: 1rem;
 }
 
 .subCategoryContainer {


### PR DESCRIPTION
# Before
<img width="662" alt="before" src="https://user-images.githubusercontent.com/814633/43434268-f500d432-9448-11e8-9fc1-ce6523302339.png">

# After
<img width="676" alt="after" src="https://user-images.githubusercontent.com/814633/43434274-f8e96fd2-9448-11e8-8c2c-2d9b1752be98.png">