### PR TITLE
Fixes square cover image sizing

### DIFF
--- a/src/css/review.css
+++ b/src/css/review.css
@@ -52,8 +52,9 @@
 }
 
 .gameMetaContainer__coverArt img {
-  height: 100%;
-  width: 100%;
+  display: block;
+  height: auto;
+  max-width: 100%;
 }
 
 .score__rating {


### PR DESCRIPTION
### Before
<img width="341" alt="image-size" src="https://user-images.githubusercontent.com/814633/44441862-d3b2ed00-a59c-11e8-8a13-566e830aa6ec.png">

### After
<img width="336" alt="fixed-imaged" src="https://user-images.githubusercontent.com/814633/44441875-ec230780-a59c-11e8-9a53-1b78116acf30.png">

Game cover image will now fill to max-height or max-width while maintaining image aspect ratio.

Will close #10.